### PR TITLE
Correct language string identifier causing unit test to fail

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -56,7 +56,7 @@ class provider implements \core_privacy\local\metadata\provider,
         $collection->add_user_preference('accessibilitytool_readtome',
             'privacy:metadata:preference:readtome');
         $collection->add_user_preference('accessibilitytool_gridformat',
-            'privacy:metadata:preference:gridformat');
+            'privacy:request:preference:gridformat');
         return $collection;
     }
 


### PR DESCRIPTION
Unit test fails due to an incorrect language string.
The correct language string looks to be here - https://github.com/sharpchi/moodle-local_accessibilitytool/blob/master/lang/en/local_accessibilitytool.php#L96

Merge requests corrects to look at that string but maybe you had a different string in mind?

```
provider_testcase::test_metadata_provider with data set "local_accessibilitytool" ('local_accessibilitytool', 'local_accessibilitytool\priva...ovider')
Expectation failed, debugging() was triggered.
Debugging: Invalid get_string() identifier: 'privacy:metadata:preference:gridformat' or component 'local_accessibilitytool'. Perhaps you are missing $string['privacy:metadata:preference:gridformat'] = ''; in /path/to/moodle/local/accessibilitytool/lang/en/local_accessibilitytool.php?
* line 353 of /lib/classes/string_manager_standard.php: call to debugging()
* line 7263 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
* line 151 of /privacy/tests/provider_test.php: call to get_string()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to provider_testcase->test_metadata_provider()
* line 842 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 80 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 693 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 796 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 652 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 206 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->doRun()
* line 162 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 61 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()

Failed asserting that 1 matches expected 0.

/path/to/moodle/lib/phpunit/classes/advanced_testcase.php:367
/path/to/moodle/privacy/tests/provider_test.php:152
/path/to/moodle/lib/phpunit/classes/advanced_testcase.php:80

To re-run:
 vendor/bin/phpunit "provider_testcase" privacy/tests/provider_test.php
```

