### PR TITLE
Extra function can be a permanent part of theme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,19 +13,22 @@ This plugin has a dependencies on Boost, and requires a call from your own theme
 ## Installing
 1.  Drop code into /local/accessibilitytool
 2.  Go to Site administration -> Notifications to install
-3.  Add
+3.  Add the following to *your* theme's lib.php file.
 ```
 function theme_yourthemename_page_init(moodle_page $page) {
     global $CFG;
-    require_once($CFG->dirroot . "/local/accessibilitytool/lib.php");
-    local_accessibilitytool_page_init($page);
+    if (file_exists($CFG->dirroot . "/local/accessibilitytool/lib.php")) {
+        require_once($CFG->dirroot . "/local/accessibilitytool/lib.php");
+        local_accessibilitytool_page_init($page);
+    }
 }
 ```
-to *your* theme's lib.php file.
+
+### Theme Developers
+Include the above function in your theme to have this plugin automatically supported once it is installed.
 
 ## Credits
 The plugin is largely based on the excellent presentation made at Moodle MootIEUK18 by
 Alex Walker ([Github](https://github.com/lexxkoto) & [Twitter](https://twitter.com/lexx_koto)) of the University of Glasgow.
-
 
 The original version was strongly tied into their theme, whereas this version is more-or-less stand-alone - requiring a small change to your theme's lib.php file.


### PR DESCRIPTION
The function that the instructions tell you to add to make this work can now be added to all themes. The plugin will then automatically be activated when the plugin is installed. As an added bonus, should the plugin be removed down the road (not wanted, no longer supported, etc), it won't break the theme because someone forgot to remove the extra function from their lib.php.